### PR TITLE
BE-683 Add new supported langs

### DIFF
--- a/source/includes/_modio.md
+++ b/source/includes/_modio.md
@@ -657,9 +657,10 @@ Language Code | Language
 `ko` | Korean
 `ru` | Russian
 `es` | Spanish (Spain)
+`es-419` | Spanish (Latin America)
+`th` | Thai
 `tr` | Turkish
 `uk` | Ukrainian
-`th` | Thai
 `zh-CN` | Chinese (Simplified)
 `zh-TW` | Chinese (Traditional)
 

--- a/source/includes/_modio.md
+++ b/source/includes/_modio.md
@@ -649,6 +649,7 @@ Language Code | Language
 `bg` | Bulgarian
 `fr` | French
 `de` | German
+`id` | Indonesian
 `it` | Italian
 `pl` | Polish
 `pt` | Portuguese

--- a/source/includes/_modio.md
+++ b/source/includes/_modio.md
@@ -656,7 +656,9 @@ Language Code | Language
 `ja` | Japanese
 `ko` | Korean
 `ru` | Russian
-`es` | Spanish
+`es` | Spanish (Spain)
+`tr` | Turkish
+`uk` | Ukrainian
 `th` | Thai
 `zh-CN` | Chinese (Simplified)
 `zh-TW` | Chinese (Traditional)


### PR DESCRIPTION
Spanish (Latin America) is intentionally omitted until legal terms are sanity checked by legal team